### PR TITLE
Added `locationId` to default parameters

### DIFF
--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -22,7 +22,8 @@ class Gateway extends AbstractGateway
     public function getDefaultParameters()
     {
         return array(
-            'accessToken' => ''
+            'accessToken' => '',
+            'locationId'  => '',
         );
     }
 


### PR DESCRIPTION
The e-commerce software I use uses the default parameters to know what settings fields to show in its admin.