### PR TITLE
Upgrade from transactions API (deprecated) to Payments and Refunds APIs

### DIFF
--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -23,6 +23,7 @@ class Gateway extends AbstractGateway
         return [
             'accessToken' => '',
             'locationId' => '',
+            'testMode' => false
         ];
     }
 
@@ -69,6 +70,21 @@ class Gateway extends AbstractGateway
     public function setAppId($value)
     {
         return $this->setParameter('appId', $value);
+    }
+
+    /**
+     * Test Mode getters and setters
+     * @return mixed
+     */
+
+    public function getTestMode()
+    {
+        return $this->getParameter('testMode');
+    }
+
+    public function setTestMode($value)
+    {
+        return $this->setParameter('testMode', $value);
     }
 
 

--- a/src/Message/ListRefundsRequest.php
+++ b/src/Message/ListRefundsRequest.php
@@ -89,17 +89,23 @@ class ListRefundsRequest extends AbstractRequest
 
     public function sendData()
     {
-        SquareConnect\Configuration::getDefaultConfiguration()->setAccessToken($this->getAccessToken());
+        $defaultApiConfig = new \SquareConnect\Configuration();
+        $defaultApiConfig->setAccessToken($this->getAccessToken());
 
-        $api_instance = new SquareConnect\Api\TransactionsApi();
+        if($this->getParameter('testMode')) {
+            $defaultApiConfig->setHost("https://connect.squareupsandbox.com");
+        }
+
+        $defaultApiClient = new \SquareConnect\ApiClient($defaultApiConfig);
+        $api_instance = new SquareConnect\Api\RefundsApi($defaultApiClient);
 
         try {
-            $result = $api_instance->listRefunds(
-                $this->getLocationId(),
+            $result = $api_instance->listPaymentRefunds(
                 $this->getBeginTime(),
                 $this->getEndTime(),
                 $this->getSortOrder(),
-                $this->getCursor()
+                $this->getCursor(),
+                $this->getLocationId()
             );
 
             if ($error = $result->getErrors()) {
@@ -117,9 +123,8 @@ class ListRefundsRequest extends AbstractRequest
                 foreach ($refundItems as $refund) {
                     $item = new \stdClass();
                     $item->id = $refund->getId();
-                    $item->tenderId = $refund->getTenderId();
                     $item->locationId = $refund->getLocationId();
-                    $item->transactionId = $refund->getTransactionId();
+                    $item->transactionId = $refund->getPaymentId();
                     $item->createdAt = $refund->getCreatedAt();
                     $item->reason = $refund->getReason();
                     $item->status = $refund->getStatus();

--- a/src/Message/ListTransactionsRequest.php
+++ b/src/Message/ListTransactionsRequest.php
@@ -89,17 +89,24 @@ class ListTransactionsRequest extends AbstractRequest
 
     public function sendData()
     {
-        SquareConnect\Configuration::getDefaultConfiguration()->setAccessToken($this->getAccessToken());
+        $defaultApiConfig = new \SquareConnect\Configuration();
+        $defaultApiConfig->setAccessToken($this->getAccessToken());
 
-        $api_instance = new SquareConnect\Api\TransactionsApi();
+        if($this->getParameter('testMode')) {
+            $defaultApiConfig->setHost("https://connect.squareupsandbox.com");
+        }
+
+        $defaultApiClient = new \SquareConnect\ApiClient($defaultApiConfig);
+
+        $api_instance = new SquareConnect\Api\PaymentsApi($defaultApiClient);
 
         try {
             $result = $api_instance->listTransactions(
-                $this->getLocationId(),
                 $this->getBeginTime(),
                 $this->getEndTime(),
                 $this->getSortOrder(),
-                $this->getCursor()
+                $this->getCursor(),
+                $this->getLocationId()
             );
 
             if ($error = $result->getErrors()) {

--- a/src/Message/RefundResponse.php
+++ b/src/Message/RefundResponse.php
@@ -12,18 +12,12 @@ class RefundResponse extends AbstractResponse
 
     public function isSuccessful()
     {
-        return $this->data['status'] === 'APPROVED';
+        return $this->data['status'] === 'APPROVED' || $this->data['status'] === 'PENDING';
     }
 
     public function getMessage()
     {
-        $message = '';
-        if (array_key_exists('code', $this->data) && strlen($this->data['code'])) {
-            $message .= $this->data['code'] . ': ';
-        }
-        if (array_key_exists('error', $this->data) && strlen($this->data['error'])) {
-            $message .= $this->data['error'];
-        }
-        return $message;
+
+        return $this->data['detail'] ?? '';
     }
 }


### PR DESCRIPTION
Transactions API [is deprecated](https://developer.squareup.com/docs/transactions-api/what-it-does), and it's been replaced by [Payments and Refunds APIs](https://developer.squareup.com/docs/payments-api/overview)

This PR does 2 things:
- Migrate to supported APIs
- Add test mode config for said APIs, to easily switch from Sandbox to Prod