### PR TITLE
Update composer require minimum version to 2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ to your `composer.json` file:
 ```json
 {
     "require": {
-        "transportersio/omnipay-square": "~2.0.0"
+        "transportersio/omnipay-square": "~2.1"
     }
 }
 ```


### PR DESCRIPTION
This also reduces the constraint to `>=2.1 / <3.0.0` vs `>=2.1 / <2.2.0`